### PR TITLE
Suppresses a warning for certain installations

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+2016-04-07  Youri Hoogstrate
+	
+	* Version 3.0.2: Suppresses a warning that occurs in some installations
+
 2016-04-05  Youri Hoogstrate
 	
 	* Version 3.0.1: Added a simple break statement ensures that the output is

--- a/fuma/ComparisonTriangle.py
+++ b/fuma/ComparisonTriangle.py
@@ -213,7 +213,7 @@ class ComparisonTriangle:
 	
 	def export_list_chunked(self,fh,chunk_fusions):
 		for fusion in chunk_fusions:
-			if fusion != None:
+			if fusion not in [None, False]:# False means marked as duplicate earlier on
 				self.export_list_fg(fusion,fh)
 				
 				if not isinstance(fusion, Fusion):

--- a/fuma/__init__.py
+++ b/fuma/__init__.py
@@ -21,7 +21,7 @@
  <http://epydoc.sourceforge.net/manual-fields.html#fields-synonyms>
 """
 
-__version_info__ = ('3', '0', '1')
+__version_info__ = ('3', '0', '2')
 __version__ = '.'.join(__version_info__) if (len(__version_info__) == 3) else '.'.join(__version_info__[0:3])+"-"+__version_info__[3]
 __author__ = 'Youri Hoogstrate'
 __homepage__ = 'https://github.com/yhoogstrate/fuma'


### PR DESCRIPTION
- Seems to happen if you run FuMa against a bioconda python instance
